### PR TITLE
compatibility fix for go 1.16.15

### DIFF
--- a/internal/hcs/service.go
+++ b/internal/hcs/service.go
@@ -1,4 +1,4 @@
-//go:build windows
+// +build windows
 
 package hcs
 


### PR DESCRIPTION
It was discovered by running the wssdagent pipeline build from the upstream. Currently the wssdagent is using go 1.16.15 and the `//go:build` convention is not compatible with 1.16.15 compiler. I did a quick scan, and the rest of the code was using `// +build` so I am changing it to make the code more compatible here.

<img width="748" alt="image" src="https://user-images.githubusercontent.com/25241284/191651238-06f0746e-c35e-4a8c-9134-16388c1e75b2.png">
